### PR TITLE
解决坐标轴标签显示不全的问题

### DIFF
--- a/iOS-Echarts/Model/PYAxisLabel.h
+++ b/iOS-Echarts/Model/PYAxisLabel.h
@@ -14,6 +14,6 @@
 @property (nonatomic, assign) BOOL show;
 @property (retain, nonatomic) PYTextStyle *textStyle;
 @property (retain, nonatomic) NSString *formatter;
-
+@property (nonatomic, strong) id interval;
 
 @end


### PR DESCRIPTION
给PYAxisLabel添加 interval 属性